### PR TITLE
Fix typo in db_service comment

### DIFF
--- a/internal/db_service.go
+++ b/internal/db_service.go
@@ -72,7 +72,7 @@ func NewDBService(
 }
 
 // Queries returns the sqlc-generated query interface.
-func (ds *PgxDBService) Queries() db.Querier { //nolint:ireturn // returns interface to encupsulate implementation details
+func (ds *PgxDBService) Queries() db.Querier { //nolint:ireturn // returns interface to encapsulate implementation details
 	return ds.queries
 }
 


### PR DESCRIPTION
## Summary
- fix a comment typo in `PgxDBService.Queries`

## Testing
- `make build_dev` *(fails: forbidden network access)*

------
https://chatgpt.com/codex/tasks/task_e_6852b0e13588833087653f9f9cf87854