### PR TITLE
Add Recovery middleware test

### DIFF
--- a/internal/middlewares/recovery_test.go
+++ b/internal/middlewares/recovery_test.go
@@ -1,0 +1,28 @@
+package middlewares_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/thara/facility_reservation_go/internal/middlewares"
+)
+
+func TestRecoveryMiddleware_Panic(t *testing.T) {
+	// Handler that panics when invoked
+	panicHandler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		panic("unexpected error")
+	})
+
+	handler := middlewares.RecoveryMiddleware(panicHandler)
+
+	req := httptest.NewRequest(http.MethodGet, "/panic", nil)
+	w := httptest.NewRecorder()
+
+	// Execute the request; the middleware should recover the panic
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "Internal Server Error")
+}


### PR DESCRIPTION
## Summary
- test RecoveryMiddleware returns HTTP 500 when a handler panics

## Testing
- `go test ./... -run TestRecoveryMiddleware -v` *(fails: go.mod requires go >= 1.24.4)*

------
https://chatgpt.com/codex/tasks/task_e_6852b10a7c508330891967ff1c7cf6f4