### PR TITLE
Update init-db mount path

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
+      - ./_scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s


### PR DESCRIPTION
## Summary
- fix the docker compose volume to use `_scripts/init-db.sql`

## Testing
- `go test ./...` *(fails: connection refused)*
- `docker compose up -d postgres` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852bc0ffa6483309d65d65571eb2c46