### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/thara/facility_reservation_go/security/code-scanning/2](https://github.com/thara/facility_reservation_go/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Since the workflow does not perform any write operations, we will set `contents: read` as the permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
