### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/thara/facility_reservation_go/security/code-scanning/1](https://github.com/thara/facility_reservation_go/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the jobs primarily involve checking out code, setting up Go, running builds, installing dependencies, and performing linting and schema checks. These actions typically require read-only access to the repository contents. Therefore, the `permissions` block should be added at the root level of the workflow to apply to all jobs, with `contents: read` as the minimal permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
