### PR TITLE
Add transaction rollback test

### DIFF
--- a/internal/db_service_test.go
+++ b/internal/db_service_test.go
@@ -176,6 +176,6 @@ func TestDatabaseService_Transaction_Rollback(t *testing.T) {
 	require.ErrorIs(t, err, intentionalErr)
 
 	_, err = store.GetUserByID(ctx, userID)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.ErrorIs(t, err, pgx.ErrNoRows)
 }


### PR DESCRIPTION
## Summary
- write an integration test that ensures the `Transaction` helper rolls back on error

## Testing
- `go test ./... -v` *(fails: failed to connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_6852bc5bcbd88330be68ac262bbb85b7